### PR TITLE
feat: adicionar hash de senha e role admin na seed prisma

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -22,9 +22,9 @@
       }
     },
     "node_modules/@prisma/client": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.13.0.tgz",
-      "integrity": "sha512-8m2+I3dQovkV8CkDMluiwEV1TxV9EXdT6xaCz39O6jYw7mkf5gwfmi+cL4LJsEPwz5tG7sreBwkRpEMJedGYUQ==",
+      "version": "6.16.1",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.16.1.tgz",
+      "integrity": "sha512-QaBCOY29lLAxEFFJgBPyW3WInCW52fJeQTmWx/h6YsP5u0bwuqP51aP0uhqFvhK9DaZPwvai/M4tSDYLVE9vRg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "engines": {
@@ -296,9 +296,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "17.2.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.1.tgz",
-      "integrity": "sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ==",
+      "version": "17.2.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.2.tgz",
+      "integrity": "sha512-Sf2LSQP+bOlhKWWyhFsn0UsfdK/kCWRv1iuA2gXAwt3dyNabr6QSj00I2V10pidqz69soatm9ZwZvpQMTIOd5Q==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -977,12 +977,13 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
-      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
       "license": "MIT",
-      "engines": {
-        "node": ">=16"
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/picomatch": {
@@ -1043,18 +1044,34 @@
       }
     },
     "node_modules/raw-body": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
-      "integrity": "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.1.tgz",
+      "integrity": "sha512-9G8cA+tuMS75+6G/TzW8OtLzmBDMo8p1JRxN5AZ+LAp8uxGA8V8GZm4GQ4/N5QNQEnLmg6SS7wyuSmbKepiKqA==",
       "license": "MIT",
       "dependencies": {
         "bytes": "3.1.2",
         "http-errors": "2.0.0",
-        "iconv-lite": "0.6.3",
+        "iconv-lite": "0.7.0",
         "unpipe": "1.0.0"
       },
       "engines": {
-        "node": ">= 0.8"
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/raw-body/node_modules/iconv-lite": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
+      "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/readdirp": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -22,5 +22,8 @@
   },
   "devDependencies": {
     "nodemon": "^3.1.10"
+  },
+  "prisma": {
+    "seed": "node prisma/seed.js"
   }
 }

--- a/backend/prisma/migrations/20250911183621_update_tables/migration.sql
+++ b/backend/prisma/migrations/20250911183621_update_tables/migration.sql
@@ -14,6 +14,7 @@ CREATE TABLE "public"."User" (
 CREATE TABLE "public"."Post" (
     "id" SERIAL NOT NULL,
     "idCreator" INTEGER NOT NULL,
+    "title" TEXT NOT NULL,
     "image" TEXT,
     "stacks" TEXT[],
     "about" TEXT NOT NULL,

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -20,6 +20,7 @@ model User {
 model Post {
   id Int @id @default(autoincrement())
   idCreator Int
+  title String
   image String?
   stacks String[]
   about String

--- a/backend/prisma/seed.js
+++ b/backend/prisma/seed.js
@@ -1,22 +1,39 @@
 import { PrismaClient } from "@prisma/client"
+import bcrypt from "bcrypt";
 const prisma = new PrismaClient()
 
-async function main() {
-  await prisma.user.createMany({
-    data: [
-      {name: "Thiago Silva", email: "thiago1@example.com", password: "senha123"},
-      {name: "Ana Costa", email: "ana2@example.com", password: "senha123"},
-      {name: "Carlos Oliveira", email: "carlos3@example.com", password: "senha123" },
-      {name: "Beatriz Souza", email: "beatriz4@example.com", password: "senha123"},
-      {name: "Eduardo Lima", email: "eduardo5@example.com", password: "senha123"},
-      {name: "Fernanda Rocha", email: "fernanda6@example.com", password: "senha123"},
-      {name: "Gustavo Martins", email: "gustavo7@example.com", password: "senha123"},
-      {name: "Juliana Alves", email: "juliana8@example.com", password: "senha123"},
-      {name: "Lucas Pereira", email: "lucas9@example.com", password: "senha123"},
-      {name: "Mariana Fernandes", email: "mariana10@example.com", password: "senha123"},
-    ],
-  })
 
+
+async function main() {
+  const usersData = [
+    { name: "adminMaster", email: "admin@email.com", password: "admin123", role: "admin" },
+    { name: "Thiago Silva", email: "thiago1@example.com", password: "senha123" },
+    { name: "Ana Costa", email: "ana2@example.com", password: "senha123" },
+    { name: "Carlos Oliveira", email: "carlos3@example.com", password: "senha123" },
+    { name: "Beatriz Souza", email: "beatriz4@example.com", password: "senha123" },
+    { name: "Eduardo Lima", email: "eduardo5@example.com", password: "senha123" },
+    { name: "Fernanda Rocha", email: "fernanda6@example.com", password: "senha123" },
+    { name: "Gustavo Martins", email: "gustavo7@example.com", password: "senha123" },
+    { name: "Juliana Alves", email: "juliana8@example.com", password: "senha123" },
+    { name: "Lucas Pereira", email: "lucas9@example.com", password: "senha123" },
+    { name: "Mariana Fernandes", email: "mariana10@example.com", password: "senha123" },
+  ];
+
+  for (const u of usersData) {
+    const hashedPassword = await bcrypt.hash(u.password, 10);
+    await prisma.user.upsert({
+      where: { email: u.email },
+      update: {},
+      create: {
+        name: u.name,
+        email: u.email,
+        password: hashedPassword,
+        role: u.role || "user",
+      },
+    });
+  }
+
+  
   await prisma.post.createMany({
     data: [
       {

--- a/backend/prisma/seed.js
+++ b/backend/prisma/seed.js
@@ -1,0 +1,180 @@
+import { PrismaClient } from "@prisma/client"
+const prisma = new PrismaClient()
+
+async function main() {
+  await prisma.user.createMany({
+    data: [
+      {name: "Thiago Silva", email: "thiago1@example.com", password: "senha123"},
+      {name: "Ana Costa", email: "ana2@example.com", password: "senha123"},
+      {name: "Carlos Oliveira", email: "carlos3@example.com", password: "senha123" },
+      {name: "Beatriz Souza", email: "beatriz4@example.com", password: "senha123"},
+      {name: "Eduardo Lima", email: "eduardo5@example.com", password: "senha123"},
+      {name: "Fernanda Rocha", email: "fernanda6@example.com", password: "senha123"},
+      {name: "Gustavo Martins", email: "gustavo7@example.com", password: "senha123"},
+      {name: "Juliana Alves", email: "juliana8@example.com", password: "senha123"},
+      {name: "Lucas Pereira", email: "lucas9@example.com", password: "senha123"},
+      {name: "Mariana Fernandes", email: "mariana10@example.com", password: "senha123"},
+    ],
+  })
+
+  await prisma.post.createMany({
+    data: [
+      {
+        idCreator: 10,
+        title: "API Node com JWT",
+        image: "https://picsum.photos/seed/api1/600/400",
+        stacks: ["Node.js", "Express", "JWT"],
+        about: "Projeto de API RESTful com autenticação JWT.",
+        linkRepo: "https://github.com/thiago/api-node",
+      },
+      {
+        idCreator: 5,
+        title: "Landing Page React",
+        image: "https://picsum.photos/seed/frontend1/600/400",
+        stacks: ["React", "TailwindCSS"],
+        about: "Landing page responsiva usando React e TailwindCSS.",
+        linkRepo: "https://github.com/thiago/landing-react",
+      },
+      {
+        idCreator: 4,
+        title: "Todo App Flutter",
+        image: "https://picsum.photos/seed/mobile1/600/400",
+        stacks: ["Flutter", "Dart"],
+        about: "Aplicativo de tarefas multiplataforma com Flutter.",
+        linkRepo: "https://github.com/ana/flutter-todo",
+      },
+      {
+        idCreator: 3,
+        title: "Dashboard Admin",
+        image: "https://picsum.photos/seed/dashboard1/600/400",
+        stacks: ["React", "Chart.js", "Node.js"],
+        about: "Dashboard admin com gráficos dinâmicos e integração API.",
+        linkRepo: "https://github.com/ana/admin-dashboard",
+      },
+      {
+        idCreator: 3,
+        title: "Chat em Tempo Real",
+        image: "https://picsum.photos/seed/chat1/600/400",
+        stacks: ["Node.js", "Socket.IO"],
+        about: "Chat em tempo real usando WebSockets.",
+        linkRepo: "https://github.com/carlos/chat-realtime",
+      },
+      {
+        idCreator: 2,
+        title: "E-commerce Next.js",
+        image: "https://picsum.photos/seed/ecommerce1/600/400",
+        stacks: ["Next.js", "Stripe", "PostgreSQL"],
+        about: "Loja virtual com SSR e integração Stripe.",
+        linkRepo: "https://github.com/beatriz/ecommerce-next",
+      },
+      {
+        idCreator: 10,
+        title: "Blog Markdown",
+        image: "https://picsum.photos/seed/blog1/600/400",
+        stacks: ["Node.js", "Markdown"],
+        about: "Blog que renderiza artigos em Markdown.",
+        linkRepo: "https://github.com/beatriz/markdown-blog",
+      },
+      {
+        idCreator: 4,
+        title: "API GraphQL Apollo",
+        image: "https://picsum.photos/seed/api2/600/400",
+        stacks: ["GraphQL", "Apollo Server"],
+        about: "API de exemplo usando GraphQL e Apollo Server.",
+        linkRepo: "https://github.com/eduardo/api-graphql",
+      },
+      {
+        idCreator: 3,
+        title: "Login Seguro Node",
+        image: "https://picsum.photos/seed/auth1/600/400",
+        stacks: ["Node.js", "JWT", "bcrypt"],
+        about: "Autenticação segura com bcrypt e JWT.",
+        linkRepo: "https://github.com/eduardo/login-secure",
+      },
+      {
+        idCreator: 4,
+        title: "Jogo da Cobrinha JS",
+        image: "https://picsum.photos/seed/game1/600/400",
+        stacks: ["JavaScript", "HTML", "CSS"],
+        about: "Jogo da cobrinha implementado em JS puro.",
+        linkRepo: "https://github.com/fernanda/js-snake",
+      },
+      {
+        idCreator: 5,
+        title: "Weather App",
+        image: "https://picsum.photos/seed/weather1/600/400",
+        stacks: ["JavaScript", "API REST"],
+        about: "App de previsão do tempo consumindo API externa.",
+        linkRepo: "https://github.com/fernanda/weather-app",
+      },
+      {
+        idCreator: 6,
+        title: "Portfolio Dev",
+        image: "https://picsum.photos/seed/portfolio1/600/400",
+        stacks: ["HTML", "CSS", "JavaScript"],
+        about: "Site pessoal responsivo para desenvolvedores.",
+        linkRepo: "https://github.com/gustavo/dev-portfolio",
+      },
+      {
+        idCreator: 7,
+        title: "API com NestJS",
+        image: "https://picsum.photos/seed/api3/600/400",
+        stacks: ["NestJS", "TypeScript"],
+        about: "API modular usando NestJS.",
+        linkRepo: "https://github.com/juliana/api-nest",
+      },
+      {
+        idCreator: 3,
+        title: "Microserviço Pagamentos",
+        image: "https://picsum.photos/seed/microservice1/600/400",
+        stacks: ["Node.js", "RabbitMQ"],
+        about: "Microserviço de pagamentos usando RabbitMQ.",
+        linkRepo: "https://github.com/juliana/microservice-payments",
+      },
+      {
+        idCreator: 9,
+        title: "CRUD com Prisma",
+        image: "https://picsum.photos/seed/crud1/600/400",
+        stacks: ["Prisma", "Express", "PostgreSQL"],
+        about: "API CRUD conectada a PostgreSQL usando Prisma ORM.",
+        linkRepo: "https://github.com/lucas/prisma-crud",
+      },
+      {
+        idCreator: 10,
+        title: "Sistema de Estoque",
+        image: "https://picsum.photos/seed/inventory1/600/400",
+        stacks: ["React", "Node.js"],
+        about: "Sistema de controle de estoque com dashboard.",
+        linkRepo: "https://github.com/lucas/inventory-system",
+      },
+      {
+        idCreator: 4,
+        title: "Finance App",
+        image: "https://picsum.photos/seed/finance1/600/400",
+        stacks: ["React Native", "Expo"],
+        about: "App de controle financeiro com gráficos interativos.",
+        linkRepo: "https://github.com/mariana/finance-app",
+      },
+      {
+        idCreator: 10,
+        title: "API Upload AWS",
+        image: "https://picsum.photos/seed/api4/600/400",
+        stacks: ["Node.js", "AWS S3"],
+        about: "API para upload e armazenamento de arquivos no AWS S3.",
+        linkRepo: "https://github.com/mariana/file-upload-api",
+      },
+    ],
+  })
+
+  console.log("✅ banco populado com sucesso!")
+}
+
+main()
+  .then(async () => {
+    await prisma.$disconnect()
+  })
+  .catch(async (e) => {
+    console.error(e)
+    await prisma.$disconnect()
+    process.exit(1)
+  })

--- a/backend/src/controllers/postController.js
+++ b/backend/src/controllers/postController.js
@@ -3,10 +3,11 @@ const prisma = new PrismaClient();
 
 export const createPost = async (req, res) => {
     try {
-        const {idCreator, image, stacks, about, linkRepo} = req.body;
+        const {idCreator, title, image, stacks, about, linkRepo} = req.body;
         const post = await prisma.post.create({
             data : {
                 idCreator : req.userId,
+                title,
                 image,
                 stacks,
                 about,

--- a/backend/src/middlewares/validatePostMiddleware.js
+++ b/backend/src/middlewares/validatePostMiddleware.js
@@ -1,8 +1,8 @@
 const validatePost = (req, res, next) => {
     
-    const { idCreator, image, stacks, about, linkRepo } = req.body;
+    const { idCreator, title, image, stacks, about, linkRepo } = req.body;
 
-    if (!idCreator || !about) {
+    if (!idCreator || !about || !title) {
         return res.status(400).json({error : "idCreator e about são obrigatorios"});
     }
 


### PR DESCRIPTION
•Atualiza o seed de usuários para salvar as senhas como hash usando bcrypt.
•Adiciona suporte para role admin e mantém role padrão "user" para os demais usuários.
•Garante que o seed possa ser rodado múltiplas vezes sem criar duplicados (usando upsert).
•Banco pronto para testes de rotas.